### PR TITLE
Add support for natbib

### DIFF
--- a/company-auctex.el
+++ b/company-auctex.el
@@ -253,7 +253,7 @@
   (interactive (list 'interactive))
   (case command
     (interactive (company-begin-backend 'company-auctex-bibs))
-    (prefix (company-auctex-prefix "\\\\cite\\(?:\\[[^]]*\\]\\)?{\\([^},]*\\)\\="))
+    (prefix (company-auctex-prefix "\\\\cite[^[{]*\\(?:\\[[^]]*\\]\\)?{\\([^},]*\\)\\="))
     (candidates (company-auctex-bib-candidates arg))))
 
 


### PR DESCRIPTION
Natbib defines several \cite commands, e.g. \citep or \citepalias. Add support for all of them by being more liberal with the prefix.

See http://merkel.zoneo.net/Latex/natbib.php for natbib's cite commands.

An alternative approach could be to explicitly add all options (citep, citeauthor*, …), but the liberal approach should be more robust and future proof.