### PR TITLE
Make backend work without yas-minor-mode enabled

### DIFF
--- a/company-auctex.el
+++ b/company-auctex.el
@@ -128,15 +128,18 @@
        (add-hook 'yas-after-exit-snippet-hook #'company-auctex--disable-yas))
      ,@body))
 
-(defun company-auctex-get-LaTeX-font-list ()
+(defun company-auctex-get-LaTeX-font-list (&optional mathp)
   (delq nil (mapcar
              (lambda (x)
                (and (stringp x)
                     (not (string-empty-p x))
                     (not (string= x "}"))
                     (substring x 1 -1)))
-             (apply 'append
-                    (delete-dups (mapcar #'cdr LaTeX-font-list))))))
+             (delete-dups
+              (mapcar (if mathp
+                          (lambda (x) (nth 3 x))
+                        #'cadr)
+                      LaTeX-font-list)))))
 
 (defun company-auctex-macro-snippet (arg-info)
   (let ((count 1))
@@ -182,7 +185,8 @@
   (append LaTeX-math-list LaTeX-math-default))
 
 (defun company-auctex-symbol-candidates (prefix)
-  (all-completions prefix (mapcar 'cadr (company-auctex-math-all))))
+  (all-completions prefix (append (mapcar 'cadr (company-auctex-math-all))
+                                  (company-auctex-get-LaTeX-font-list t))))
 
 (defun company-auctex-symbol-post-completion (candidate)
   (search-backward candidate)

--- a/company-auctex.el
+++ b/company-auctex.el
@@ -128,6 +128,16 @@
        (add-hook 'yas-after-exit-snippet-hook #'company-auctex--disable-yas))
      ,@body))
 
+(defun company-auctex-get-LaTeX-font-list ()
+  (delq nil (mapcar
+             (lambda (x)
+               (and (stringp x)
+                    (not (string-empty-p x))
+                    (not (string= x "}"))
+                    (substring x 1 -1)))
+             (apply 'append
+                    (delete-dups (mapcar #'cdr LaTeX-font-list))))))
+
 (defun company-auctex-macro-snippet (arg-info)
   (let ((count 1))
     (apply 'concat
@@ -139,10 +149,12 @@
     (yas-expand-snippet (company-auctex-macro-snippet (assoc-default str env)))))
 
 (defun company-auctex-macro-candidates (prefix)
-  (let ((comlist (mapcar (lambda (item) (car-or (car item)))
-                         (append (TeX-symbol-list)
-                                 (LaTeX-length-list)
-                                 LaTeX-section-list))))
+  (let ((comlist (append
+                  (mapcar (lambda (item) (car-or (car item)))
+                          (append (TeX-symbol-list)
+                                  (LaTeX-length-list)
+                                  LaTeX-section-list))
+                  (company-auctex-get-LaTeX-font-list))))
     (all-completions prefix comlist)))
 
 (defun company-auctex-macro-post-completion (candidate)


### PR DESCRIPTION
I don't enable yasnippet in the AUCTeX buffer, but I find `company-auctex`(and the original `auto-complete-auctex`) uses `yas-expand-snippet` to expand a snippet, which will cause error when `yas-minor-mode` is not enabled in current buffer. In this pull request, it checks whether `yas-minor-mode` is on before calling `yas-expand-snippet`. If not, enable it and disable it after the expansion.

I also added some font changing commands which should fix issue #10.