### PR TITLE
Fix for string-empty-p

### DIFF
--- a/company-auctex.el
+++ b/company-auctex.el
@@ -132,7 +132,7 @@
   (delq nil (mapcar
              (lambda (x)
                (and (stringp x)
-                    (not (string-empty-p x))
+                    (not (string= x ""))
                     (not (string= x "}"))
                     (list (substring x 1 -1) t)))
              (delete-dups


### PR DESCRIPTION
string-empty-p was introduced at Emacs 24.4 and subr-x.el must be loaded for
using it.