### PR TITLE
Support label completion in \eqref and \autoref as well as \ref

### DIFF
--- a/company-auctex.el
+++ b/company-auctex.el
@@ -264,7 +264,7 @@
   (interactive (list 'interactive))
   (cl-case command
     (interactive (company-begin-backend 'company-auctex-labels))
-    (prefix (company-auctex-prefix "\\\\ref{\\([^}]*\\)\\="))
+    (prefix (company-auctex-prefix "\\\\\\(?:eq\\|auto\\)?ref{\\([^}]*\\)\\="))
     (candidates (company-auctex-label-candidates arg))))
 
 


### PR DESCRIPTION
`\ref` isn't the only referencing macro.