### PR TITLE
Support label completion in \cref  (Clever Ref)

### DIFF
--- a/company-auctex.el
+++ b/company-auctex.el
@@ -264,7 +264,7 @@
   (interactive (list 'interactive))
   (cl-case command
     (interactive (company-begin-backend 'company-auctex-labels))
-    (prefix (company-auctex-prefix "\\\\\\(?:eq\\|auto\\)?ref{\\([^}]*\\)\\="))
+    (prefix (company-auctex-prefix "\\\\\\(?:eq\\|auto\\|c\\)?ref{\\([^}]*\\)\\="))
     (candidates (company-auctex-label-candidates arg))))
 
 


### PR DESCRIPTION
Basically the same as f24de90a14c46fc3b924875c658b319c7f209aff. 